### PR TITLE
Improve validator for "Open" events

### DIFF
--- a/lib/hanreki/event.rb
+++ b/lib/hanreki/event.rb
@@ -85,6 +85,12 @@ class Event
       raise ArgumentError, 'both summaries are not set'
     end
 
+    if @public_summary == 'Open'
+      if @start == @end
+        raise ArgumentError, '"open" event should have duration'
+      end
+    end
+
     if @private_summary == 'Closed'
       if not @public_summary.nil?
         raise ArgumentError, 'invalid public summary for a closed event'

--- a/spec/hanreki/event_spec.rb
+++ b/spec/hanreki/event_spec.rb
@@ -244,6 +244,24 @@ describe Event do
       it { is_expected.to raise_error(ArgumentError) }
     end
 
+    context 'when public summary is "Open"' do
+      before do
+        event.public_summary = 'Open'
+        event.private_summary = '@ymyzk'
+      end
+
+      context 'when start == end' do
+        before do
+          event.start = Time.new(2016, 10, 7, 0, 0, 0, '+09:00')
+          event.end = Time.new(2016, 10, 7, 0, 0, 0, '+09:00')
+        end
+
+        subject { -> { event.validate } }
+
+        it { is_expected.to raise_error(ArgumentError) }
+      end
+    end
+
     context 'when private summary is "Closed"' do
       before do
         event.public_summary = nil


### PR DESCRIPTION
"Open" events should have have duration at least 1 minute.
For example, `12,月,00:00,00:00,Open,@ymyzk,` should be rejected by the validator.
