### PR TITLE
Fix warning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 language: ruby
 rvm:
   - 2.1
-  - 2.2
+  - 2.2.4
   - 2.3.1
   - 2.4.0
 before_install:

--- a/lib/hanreki/time_util.rb
+++ b/lib/hanreki/time_util.rb
@@ -2,10 +2,10 @@ require 'time'
 
 # Add some useful methods to Time, provided as refinement
 module ExtendTime
-  refine Time do
-    SECONDS_OF_HOUR = 60 * 60
-    SECONDS_OF_DAY = SECONDS_OF_HOUR * 24
+  SECONDS_OF_HOUR = 60 * 60
+  SECONDS_OF_DAY = SECONDS_OF_HOUR * 24
 
+  refine Time do
     # n 日後の Time を返す
     def next_day(n = 1)
       self + (n * SECONDS_OF_DAY)


### PR DESCRIPTION
ruby 2.4での
`hanreki/lib/hanreki/time_util.rb:6: warning: not defined at the refinement, but at the outer class/module‘`
の修正