### PR TITLE
Remove circle.yml

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,8 +1,0 @@
-machine:
-  timezone:
-    UTC
-  ruby:
-    version: 2.1.5
-dependencies:
-  pre:
-    - gem install bundler


### PR DESCRIPTION
We use Travis CI as a CI service for hanreki.
`circle.yml` is not maintained anymore, so we should remove it.