### PR TITLE
Stop including unnecessary files to gem

### DIFF
--- a/hanreki.gemspec
+++ b/hanreki.gemspec
@@ -14,7 +14,12 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/camphor-/hanreki'
   spec.license       = 'MIT'
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files         = `git ls-files -z`.split("\x0").reject { |f|
+                         f.match(%r{^(
+                           (bin|test|spec|features)/|
+                           \.gitignore|\.rspec|\.travis\.yml|Rakefile
+                         )}x)
+                       }
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']


### PR DESCRIPTION
Unnecessary files such as `.travis.yml` and `.travis.yml` are included in a gem file.
We should not include them.