### PR TITLE
Drop Ruby 2.1.x support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.1
   - 2.2.4
   - 2.3.1
   - 2.4.0

--- a/hanreki.gemspec
+++ b/hanreki.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.1.0'
+  spec.required_ruby_version = '>= 2.2.0'
 
   spec.add_dependency 'thor', '~> 0.19'
   spec.add_dependency 'icalendar', '~> 2.3'


### PR DESCRIPTION
Support of Ruby 2.1 has ended on April 1st.
See https://www.ruby-lang.org/ja/news/2017/04/01/support-of-ruby-2-1-has-ended/ for more details.